### PR TITLE
feat(timeline): populate full career timeline and polish UI

### DIFF
--- a/src/cv/CVEntry.tsx
+++ b/src/cv/CVEntry.tsx
@@ -5,11 +5,16 @@ const itemStyle = css(`
   position: relative;
   display: flex;
   gap: 10px;
-  padding: 5px 0;
+  padding: 6px 0;
   font-size: 14px;
-  line-height: 1.6;
+  line-height: 1.65;
   color: inherit;
   list-style: none;
+  transition: transform 160ms cubic-bezier(0.16, 1, 0.3, 1);
+
+  &:hover {
+    transform: translateX(4px);
+  }
 
   &:hover .cv-tooltip {
     opacity: 1;

--- a/src/cv/entries.test.tsx
+++ b/src/cv/entries.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+import type { ComponentType } from 'react';
+import { describe, expect, it } from 'vitest';
+
+// Eager-load every month entry component so each default export is exercised.
+// This is a smoke test: verifies the component renders without throwing and
+// produces at least one list item (CVEntry renders <li>).
+const modules = import.meta.glob<{ default: ComponentType }>(
+  './entries/**/*.tsx',
+  { eager: true },
+);
+
+describe('cv month entries – smoke render', () => {
+  const entries = Object.entries(modules);
+
+  it('discovers all expected entry files', () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  for (const [path, mod] of entries) {
+    it(`${path} renders without crashing and produces at least one item`, () => {
+      const { container } = render(
+        <ul>
+          <mod.default />
+        </ul>,
+      );
+      const items = container.querySelectorAll('li');
+      expect(items.length).toBeGreaterThan(0);
+    });
+  }
+});

--- a/src/cv/entries/2023/07.tsx
+++ b/src/cv/entries/2023/07.tsx
@@ -1,0 +1,10 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function July2023() {
+  return (
+    <>
+      <CVEntry>Started working at Mindgate Solutions as a Software Engineer</CVEntry>
+      <CVEntry>Began new college graduate training program</CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2023/07.tsx
+++ b/src/cv/entries/2023/07.tsx
@@ -3,7 +3,9 @@ import { CVEntry } from '../../CVEntry';
 export default function July2023() {
   return (
     <>
-      <CVEntry>Started working at Mindgate Solutions as a Software Engineer</CVEntry>
+      <CVEntry>
+        Started working at Mindgate Solutions as a Software Engineer
+      </CVEntry>
       <CVEntry>Began new college graduate training program</CVEntry>
     </>
   );

--- a/src/cv/entries/2023/08.tsx
+++ b/src/cv/entries/2023/08.tsx
@@ -1,0 +1,15 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function August2023() {
+  return (
+    <>
+      <CVEntry tooltip="Angular, Python, Java, Spring Boot">
+        Completed multi-language training track
+      </CVEntry>
+      <CVEntry>Received training in Aerospike and Kafka</CVEntry>
+      <CVEntry tooltip="Spring Boot CRUD application">
+        Completed placement project to conclude training
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2023/09.tsx
+++ b/src/cv/entries/2023/09.tsx
@@ -1,0 +1,15 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function September2023() {
+  return (
+    <>
+      <CVEntry tooltip="Two-week placement project determining team assignment">
+        Built two-way NPCI–CBS bank data reconciliation system with team
+      </CVEntry>
+      <CVEntry tooltip="Achieved 1k records per second throughput">
+        Hit reconciliation throughput target of 1k/sec
+      </CVEntry>
+      <CVEntry>Placed on direct product group</CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2023/10.tsx
+++ b/src/cv/entries/2023/10.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function October2023() {
+  return (
+    <>
+      <CVEntry tooltip="Monolith UPI system migrating to microservices architecture">
+        Joined UPI modernisation migration project
+      </CVEntry>
+      <CVEntry tooltip="Reduced codebase from 10k to 1k lines of code; owned issuer-side UPI pin management">
+        Created and owned Pin Management Microservice for all UPI customers
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2023/11.tsx
+++ b/src/cv/entries/2023/11.tsx
@@ -1,0 +1,12 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function November2023() {
+  return (
+    <>
+      <CVEntry>Deployed Pin Management Service with basic test coverage</CVEntry>
+      <CVEntry>
+        Started Operational Compliance system handling transaction validation rule changes
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2023/11.tsx
+++ b/src/cv/entries/2023/11.tsx
@@ -3,9 +3,12 @@ import { CVEntry } from '../../CVEntry';
 export default function November2023() {
   return (
     <>
-      <CVEntry>Deployed Pin Management Service with basic test coverage</CVEntry>
       <CVEntry>
-        Started Operational Compliance system handling transaction validation rule changes
+        Deployed Pin Management Service with basic test coverage
+      </CVEntry>
+      <CVEntry>
+        Started Operational Compliance system handling transaction validation
+        rule changes
       </CVEntry>
     </>
   );

--- a/src/cv/entries/2023/12.tsx
+++ b/src/cv/entries/2023/12.tsx
@@ -4,7 +4,8 @@ export default function December2023() {
   return (
     <>
       <CVEntry tooltip="Latency reduced from 100ms to 1ms on the previous system">
-        Delivered Operational Compliance system with order-of-magnitude latency improvement
+        Delivered Operational Compliance system with order-of-magnitude latency
+        improvement
       </CVEntry>
       <CVEntry tooltip="New hash key algorithm for effective Aerospike data sharding — not shipped in time">
         Worked on hash key algorithm for effective data sharding

--- a/src/cv/entries/2023/12.tsx
+++ b/src/cv/entries/2023/12.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function December2023() {
+  return (
+    <>
+      <CVEntry tooltip="Latency reduced from 100ms to 1ms on the previous system">
+        Delivered Operational Compliance system with order-of-magnitude latency improvement
+      </CVEntry>
+      <CVEntry tooltip="New hash key algorithm for effective Aerospike data sharding — not shipped in time">
+        Worked on hash key algorithm for effective data sharding
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2024/01.tsx
+++ b/src/cv/entries/2024/01.tsx
@@ -1,0 +1,17 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function January2024() {
+  return (
+    <>
+      <CVEntry tooltip="Moves most post-transaction operations off the critical transaction path via async event consumers">
+        Designed event-based consumer architecture to reduce pressure on transaction services
+      </CVEntry>
+      <CVEntry>
+        Built consumer that transforms received data for Non Real-time Fraud Detection system
+      </CVEntry>
+      <CVEntry tooltip="Reduced field copy count per transaction from 30 to 0 using runtime annotation-based filtering">
+        Optimised transaction service producer — eliminated all field copy operations
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2024/01.tsx
+++ b/src/cv/entries/2024/01.tsx
@@ -4,13 +4,16 @@ export default function January2024() {
   return (
     <>
       <CVEntry tooltip="Moves most post-transaction operations off the critical transaction path via async event consumers">
-        Designed event-based consumer architecture to reduce pressure on transaction services
+        Designed event-based consumer architecture to reduce pressure on
+        transaction services
       </CVEntry>
       <CVEntry>
-        Built consumer that transforms received data for Non Real-time Fraud Detection system
+        Built consumer that transforms received data for Non Real-time Fraud
+        Detection system
       </CVEntry>
       <CVEntry tooltip="Reduced field copy count per transaction from 30 to 0 using runtime annotation-based filtering">
-        Optimised transaction service producer — eliminated all field copy operations
+        Optimised transaction service producer — eliminated all field copy
+        operations
       </CVEntry>
     </>
   );

--- a/src/cv/entries/2024/02.tsx
+++ b/src/cv/entries/2024/02.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function February2024() {
+  return (
+    <>
+      <CVEntry tooltip="Aerospike produces events keyed to Kafka partitions; consumer syncs to backup data store">
+        Built data-syncing consumer as backup store for all Aerospike changes
+      </CVEntry>
+      <CVEntry tooltip="Parallelisation with per-key ordering to ensure consistent state; minimal config per table">
+        Designed per-key synchronised consumer achieving 10k TPS
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2024/03.tsx
+++ b/src/cv/entries/2024/03.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function March2024() {
+  return (
+    <>
+      <CVEntry tooltip="Highest possible internal rating with a significant cash bonus">
+        Received top performance rating (A) and bonus for the year
+      </CVEntry>
+      <CVEntry>
+        Developed complete understanding of UPI end-to-end architecture as a solution
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2024/03.tsx
+++ b/src/cv/entries/2024/03.tsx
@@ -7,7 +7,8 @@ export default function March2024() {
         Received top performance rating (A) and bonus for the year
       </CVEntry>
       <CVEntry>
-        Developed complete understanding of UPI end-to-end architecture as a solution
+        Developed complete understanding of UPI end-to-end architecture as a
+        solution
       </CVEntry>
     </>
   );

--- a/src/cv/entries/2024/04.tsx
+++ b/src/cv/entries/2024/04.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function April2024() {
+  return (
+    <>
+      <CVEntry tooltip="OC required 48 hours of data to be valid before production switch">
+        Designed production rollout strategy for Operational Compliance data migration
+      </CVEntry>
+      <CVEntry tooltip="Fully extensible across tables; encryption algorithm change for account numbers; 300M records migrated in 10 minutes">
+        Built database migration tool for account number re-encryption at scale
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2024/04.tsx
+++ b/src/cv/entries/2024/04.tsx
@@ -4,7 +4,8 @@ export default function April2024() {
   return (
     <>
       <CVEntry tooltip="OC required 48 hours of data to be valid before production switch">
-        Designed production rollout strategy for Operational Compliance data migration
+        Designed production rollout strategy for Operational Compliance data
+        migration
       </CVEntry>
       <CVEntry tooltip="Fully extensible across tables; encryption algorithm change for account numbers; 300M records migrated in 10 minutes">
         Built database migration tool for account number re-encryption at scale

--- a/src/cv/entries/2024/09.tsx
+++ b/src/cv/entries/2024/09.tsx
@@ -1,0 +1,13 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function September2024() {
+  return (
+    <>
+      <CVEntry>Joined Adobe Systems — cloud security engineering team, Noida</CVEntry>
+      <CVEntry tooltip="Image Factory provides hardened cloud images to all of Adobe across cloud providers">
+        Started KTLO operations for Image Factory
+      </CVEntry>
+      <CVEntry>Fixed bugs in hardener that hardens running instances across clouds</CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2024/09.tsx
+++ b/src/cv/entries/2024/09.tsx
@@ -3,11 +3,15 @@ import { CVEntry } from '../../CVEntry';
 export default function September2024() {
   return (
     <>
-      <CVEntry>Joined Adobe Systems — cloud security engineering team, Noida</CVEntry>
+      <CVEntry>
+        Joined Adobe Systems — cloud security engineering team, Noida
+      </CVEntry>
       <CVEntry tooltip="Image Factory provides hardened cloud images to all of Adobe across cloud providers">
         Started KTLO operations for Image Factory
       </CVEntry>
-      <CVEntry>Fixed bugs in hardener that hardens running instances across clouds</CVEntry>
+      <CVEntry>
+        Fixed bugs in hardener that hardens running instances across clouds
+      </CVEntry>
     </>
   );
 }

--- a/src/cv/entries/2024/10.tsx
+++ b/src/cv/entries/2024/10.tsx
@@ -1,0 +1,12 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function October2024() {
+  return (
+    <>
+      <CVEntry tooltip="Reduced development time from 4 weeks to 1.5 weeks; automated grunt tasks to 5-minute execution">
+        Built script generation automation for two closely related OS families
+      </CVEntry>
+      <CVEntry>Fixed production-impacting bugs in hardening scripts</CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2024/11.tsx
+++ b/src/cv/entries/2024/11.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function November2024() {
+  return (
+    <>
+      <CVEntry tooltip="Kernel-level and similar tickets were incorrectly routed to non-owner teams; paginated API + UI corrected routing">
+        Built vulnerability ticket routing UI and paginated API
+      </CVEntry>
+      <CVEntry tooltip="Reduced onboarding from 2 weeks of manual work to 5 minutes of automation">
+        Created full EKS onboarding automation for closely related EKS flavors
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2024/12.tsx
+++ b/src/cv/entries/2024/12.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function December2024() {
+  return (
+    <>
+      <CVEntry tooltip="Each OS update pipeline creates new hardener; each hardener creates new images; owned the full cycle">
+        Became primary release engineer for hardened cloud images
+      </CVEntry>
+      <CVEntry tooltip="Strict 2-week timeline across 50+ flavors">
+        Shipped ~50 fixes and PRs in a single release cycle
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2025/01.tsx
+++ b/src/cv/entries/2025/01.tsx
@@ -1,0 +1,12 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function January2025() {
+  return (
+    <>
+      <CVEntry>Continued release engineering responsibilities</CVEntry>
+      <CVEntry tooltip="2–3 user-reported issues resolved per week via Slack channel">
+        Became primary responder for ImageFactory user support
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2025/02.tsx
+++ b/src/cv/entries/2025/02.tsx
@@ -1,0 +1,12 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function February2025() {
+  return (
+    <>
+      <CVEntry tooltip="18 hardeners migrated to virtual repositories at both upload and download jobs">
+        Shipped large-scale JFrog Artifactory virtual repository migration PR
+      </CVEntry>
+      <CVEntry>Continued release engineering</CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2025/03.tsx
+++ b/src/cv/entries/2025/03.tsx
@@ -1,0 +1,9 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function March2025() {
+  return (
+    <>
+      <CVEntry>Continued release engineering responsibilities</CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2025/04.tsx
+++ b/src/cv/entries/2025/04.tsx
@@ -1,0 +1,17 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function April2025() {
+  return (
+    <>
+      <CVEntry tooltip="Release work handed over to contract workers">
+        Transitioned release engineering responsibilities
+      </CVEntry>
+      <CVEntry tooltip="Enabled major teams to onboard to ImageFactory">
+        Added Ubuntu 24 hardener support to ImageFactory
+      </CVEntry>
+      <CVEntry tooltip="Jenkins-based Image Factory replaced; integrated with Adobe's wider security provisioning and looping architecture">
+        Became primary developer for ImageBuilder — next-generation ImageFactory
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2025/05.tsx
+++ b/src/cv/entries/2025/05.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function May2025() {
+  return (
+    <>
+      <CVEntry tooltip="Self-taught; immediately started delivering to fill heavy team gap in frontend">
+        Ramped on UI development for ImageBuilder
+      </CVEntry>
+      <CVEntry tooltip="Actively incorporated feedback and handled system-breaking events throughout">
+        Merged 100+ PRs for UI within the month
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2025/07.tsx
+++ b/src/cv/entries/2025/07.tsx
@@ -4,7 +4,8 @@ export default function July2025() {
   return (
     <>
       <CVEntry tooltip="Given an image for a flavor and service, ensure it is shared to different regions and accounts at scale">
-        Designed and implemented first event-based workload — image distribution service
+        Designed and implemented first event-based workload — image distribution
+        service
       </CVEntry>
       <CVEntry tooltip="Horizontal scale with no data duplication or deletion guarantees">
         Built reliable distributed image sharing across regions and accounts

--- a/src/cv/entries/2025/07.tsx
+++ b/src/cv/entries/2025/07.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function July2025() {
+  return (
+    <>
+      <CVEntry tooltip="Given an image for a flavor and service, ensure it is shared to different regions and accounts at scale">
+        Designed and implemented first event-based workload — image distribution service
+      </CVEntry>
+      <CVEntry tooltip="Horizontal scale with no data duplication or deletion guarantees">
+        Built reliable distributed image sharing across regions and accounts
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2025/08.tsx
+++ b/src/cv/entries/2025/08.tsx
@@ -7,9 +7,12 @@ export default function August2025() {
         Completed John Crickett challenge: Word Count tool in C++20
       </CVEntry>
       <CVEntry tooltip="Memory-mapped files (Boost.Iostreams) &lt;100MB; buffered ifstream for smaller; stdin — all behind UniversalInputStream API">
-        Implemented adaptive I/O with single-pass counting pipeline via chained FSMs
+        Implemented adaptive I/O with single-pass counting pipeline via chained
+        FSMs
       </CVEntry>
-      <CVEntry>Created own E2E test suite on top of provided challenge test suite</CVEntry>
+      <CVEntry>
+        Created own E2E test suite on top of provided challenge test suite
+      </CVEntry>
     </>
   );
 }

--- a/src/cv/entries/2025/08.tsx
+++ b/src/cv/entries/2025/08.tsx
@@ -1,0 +1,15 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function August2025() {
+  return (
+    <>
+      <CVEntry tooltip="POSIX-style wc clone in C++20; ~1.7k LOC; supports -l, -w, -c, -m, multiple files, stdin, and right-aligned totals">
+        Completed John Crickett challenge: Word Count tool in C++20
+      </CVEntry>
+      <CVEntry tooltip="Memory-mapped files (Boost.Iostreams) &lt;100MB; buffered ifstream for smaller; stdin — all behind UniversalInputStream API">
+        Implemented adaptive I/O with single-pass counting pipeline via chained FSMs
+      </CVEntry>
+      <CVEntry>Created own E2E test suite on top of provided challenge test suite</CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2025/10.tsx
+++ b/src/cv/entries/2025/10.tsx
@@ -4,7 +4,8 @@ export default function October2025() {
   return (
     <>
       <CVEntry tooltip="Driven by transition tables and rule engines">
-        Implemented Lifetime Watcher — always-active system updating image lifetime status
+        Implemented Lifetime Watcher — always-active system updating image
+        lifetime status
       </CVEntry>
       <CVEntry tooltip="Single images: Pre-Service → In-Service; Bulk images: In-Service → Post">
         Handled both single and bulk image lifetime transitions

--- a/src/cv/entries/2025/10.tsx
+++ b/src/cv/entries/2025/10.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function October2025() {
+  return (
+    <>
+      <CVEntry tooltip="Driven by transition tables and rule engines">
+        Implemented Lifetime Watcher — always-active system updating image lifetime status
+      </CVEntry>
+      <CVEntry tooltip="Single images: Pre-Service → In-Service; Bulk images: In-Service → Post">
+        Handled both single and bulk image lifetime transitions
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2025/11.tsx
+++ b/src/cv/entries/2025/11.tsx
@@ -4,7 +4,8 @@ export default function November2025() {
   return (
     <>
       <CVEntry tooltip="Entirely new codebase with unfamiliar testing patterns, styles, and architecture">
-        Solely drove planning, implementation, and contribution to central Developer Home Portal
+        Solely drove planning, implementation, and contribution to central
+        Developer Home Portal
       </CVEntry>
     </>
   );

--- a/src/cv/entries/2025/11.tsx
+++ b/src/cv/entries/2025/11.tsx
@@ -1,0 +1,11 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function November2025() {
+  return (
+    <>
+      <CVEntry tooltip="Entirely new codebase with unfamiliar testing patterns, styles, and architecture">
+        Solely drove planning, implementation, and contribution to central Developer Home Portal
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2025/12.tsx
+++ b/src/cv/entries/2025/12.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function December2025() {
+  return (
+    <>
+      <CVEntry tooltip="Manages user → directory → group → resource access; AI-interfaceable; solves core org-wide security problem; won USD 100">
+        Won 1-week Garage Week project — AI-interfaceable access management system
+      </CVEntry>
+      <CVEntry tooltip="Fleet health status across all flavors onboarded to ImageBuilder">
+        Added Operations Dashboard showing fleet health for ImageBuilder
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2025/12.tsx
+++ b/src/cv/entries/2025/12.tsx
@@ -4,7 +4,8 @@ export default function December2025() {
   return (
     <>
       <CVEntry tooltip="Manages user → directory → group → resource access; AI-interfaceable; solves core org-wide security problem; won USD 100">
-        Won 1-week Garage Week project — AI-interfaceable access management system
+        Won 1-week Garage Week project — AI-interfaceable access management
+        system
       </CVEntry>
       <CVEntry tooltip="Fleet health status across all flavors onboarded to ImageBuilder">
         Added Operations Dashboard showing fleet health for ImageBuilder

--- a/src/cv/entries/2026/02.tsx
+++ b/src/cv/entries/2026/02.tsx
@@ -1,0 +1,14 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function February2026() {
+  return (
+    <>
+      <CVEntry tooltip="C++23; lexer + recursive-descent parser; ~1.7K LOC; 368 test cases (100% pass); UTF-8-aware tokenization; CERT/secure C++ guidelines; zero-copy tokenization via string_view">
+        Completed John Crickett challenge: JSON Parser in C++23
+      </CVEntry>
+      <CVEntry tooltip="Huffman encoder/decoder in C++23; custom binary format; UTF-8 support; 80+ unit/round-trip tests; O(n) two-queue tree build; iterative traversal; RAII file handling">
+        Completed John Crickett challenge: Huffman Compression Tool in C++23
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2026/04.tsx
+++ b/src/cv/entries/2026/04.tsx
@@ -4,7 +4,8 @@ export default function April2026() {
   return (
     <>
       <CVEntry>
-        Started AI project to fully automate ImageBuilder Operations Dashboard management
+        Started AI project to fully automate ImageBuilder Operations Dashboard
+        management
       </CVEntry>
     </>
   );

--- a/src/cv/entries/2026/04.tsx
+++ b/src/cv/entries/2026/04.tsx
@@ -1,0 +1,11 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function April2026() {
+  return (
+    <>
+      <CVEntry>
+        Started AI project to fully automate ImageBuilder Operations Dashboard management
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2026/05.tsx
+++ b/src/cv/entries/2026/05.tsx
@@ -8,7 +8,8 @@ export default function May2026() {
       </CVEntry>
       <CVEntry>Continued work on Operational Dashboard Automation</CVEntry>
       <CVEntry tooltip="Passes full GNU coreutils test suite for all spec-matching tests; created entirely with AI to benchmark private harness quality">
-        Completed John Crickett cut tool challenge — passes GNU coreutils test suite
+        Completed John Crickett cut tool challenge — passes GNU coreutils test
+        suite
       </CVEntry>
     </>
   );

--- a/src/cv/entries/2026/05.tsx
+++ b/src/cv/entries/2026/05.tsx
@@ -1,0 +1,15 @@
+import { CVEntry } from '../../CVEntry';
+
+export default function May2026() {
+  return (
+    <>
+      <CVEntry tooltip="Finds changes per component, diffs against last version, collects changelog entries automatically; shipped with AI assistance in 3 days">
+        Built automated CHANGELOG generation job for hardeners
+      </CVEntry>
+      <CVEntry>Continued work on Operational Dashboard Automation</CVEntry>
+      <CVEntry tooltip="Passes full GNU coreutils test suite for all spec-matching tests; created entirely with AI to benchmark private harness quality">
+        Completed John Crickett cut tool challenge — passes GNU coreutils test suite
+      </CVEntry>
+    </>
+  );
+}

--- a/src/cv/entries/2026/06.tsx
+++ b/src/cv/entries/2026/06.tsx
@@ -3,15 +3,14 @@ import { CVEntry } from '../../CVEntry';
 export default function June2026() {
   return (
     <>
-      <CVEntry tooltip="3-column editorial header, Geist Variable font, amber monogram accent">
-        Redesigned personal blog to Editorial Precision direction
+      <CVEntry tooltip="Personal commitment to avoid staying just a corporate drone">
+        Decided to invest seriously in self-improvement beyond day job
       </CVEntry>
-      <CVEntry tooltip="Lazy loading per month, IntersectionObserver sentinel, configurable batch size">
-        Implemented reverse-chronological engineering timeline page
+      <CVEntry tooltip="Research-paper style: every section answers a question; covers engineering of dynamic plugin systems at a deep level">
+        Writing engineering paper on dynamic plugin system architecture
       </CVEntry>
-      <CVEntry tooltip="light-dark() on page shell fixes OS dark-mode + site light-mode mismatch">
-        Fixed post content text visibility across theme combinations
-      </CVEntry>
+      <CVEntry>Reframing all learning as engineering problems to produce research work</CVEntry>
+      <CVEntry>Building products and solutions from research, especially targeting defense</CVEntry>
     </>
   );
 }

--- a/src/cv/entries/2026/06.tsx
+++ b/src/cv/entries/2026/06.tsx
@@ -9,8 +9,13 @@ export default function June2026() {
       <CVEntry tooltip="Research-paper style: every section answers a question; covers engineering of dynamic plugin systems at a deep level">
         Writing engineering paper on dynamic plugin system architecture
       </CVEntry>
-      <CVEntry>Reframing all learning as engineering problems to produce research work</CVEntry>
-      <CVEntry>Building products and solutions from research, especially targeting defense</CVEntry>
+      <CVEntry>
+        Reframing all learning as engineering problems to produce research work
+      </CVEntry>
+      <CVEntry>
+        Building products and solutions from research, especially targeting
+        defense
+      </CVEntry>
     </>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,18 @@
   }
 }
 
+/* CV entry reveal — runs once when a month's lazy component mounts into the DOM */
+@keyframes cv-entries-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 body {
   margin: 0;
   font-family:

--- a/src/pages/Timeline/BatchControl.tsx
+++ b/src/pages/Timeline/BatchControl.tsx
@@ -12,17 +12,17 @@ const groupStyle = css(`
 const labelStyle = css(`
   font-size: 11px;
   font-weight: 500;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: light-dark(#78716c, #a8a29e);
-  margin-right: 8px;
+  color: light-dark(#a8a29e, #78716c);
+  margin-right: 6px;
   user-select: none;
 `);
 
 const btnStyle = css(`
-  width: 28px;
-  height: 24px;
-  border-radius: 4px;
+  width: 30px;
+  height: 26px;
+  border-radius: 5px;
   border: 1px solid light-dark(#e8e7e5, #282624);
   background: transparent;
   font-size: 12px;
@@ -30,11 +30,15 @@ const btnStyle = css(`
   font-family: inherit;
   cursor: pointer;
   color: light-dark(#78716c, #a8a29e);
-  transition: color 120ms ease, border-color 120ms ease, background-color 120ms ease;
+  transition: color 120ms ease, border-color 120ms ease, background-color 120ms ease, transform 120ms ease;
 
   &:hover {
     border-color: light-dark(#b45309, #d97706);
     color: light-dark(#b45309, #d97706);
+  }
+
+  &:active {
+    transform: scale(0.95);
   }
 `);
 

--- a/src/pages/Timeline/MonthSection.tsx
+++ b/src/pages/Timeline/MonthSection.tsx
@@ -6,17 +6,20 @@ import type { MonthEntry } from '../../cv/types';
 import { monthSectionProps } from './monthSectionDom';
 
 const sectionStyle = css(`
-  padding: 32px 0 48px;
+  padding: 44px 0 64px;
   border-bottom: 1px solid light-dark(#e8e7e5, #282624);
   scroll-margin-top: 24px;
 `);
 
 const headingStyle = css(`
-  font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+  font-size: clamp(1.4rem, 3vw, 1.85rem);
   font-weight: 700;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.045em;
+  line-height: 1;
   color: inherit;
-  margin: 0 0 20px;
+  margin: 0 0 28px;
+  padding-left: 12px;
+  border-left: 2.5px solid light-dark(#b45309, #d97706);
 `);
 
 const listStyle = css(`
@@ -24,6 +27,11 @@ const listStyle = css(`
   padding: 0;
   display: flex;
   flex-direction: column;
+  will-change: opacity, transform;
+
+  @media (prefers-reduced-motion: no-preference) {
+    animation: cv-entries-in 0.45s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
 `);
 
 const loadingStyle = css(`

--- a/src/pages/Timeline/component.tsx
+++ b/src/pages/Timeline/component.tsx
@@ -29,10 +29,22 @@ const sentinelStyle = css(`
 `);
 
 const endNoteStyle = css(`
-  font-size: 13px;
-  color: light-dark(#78716c, #a8a29e);
-  padding: 32px 0;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: light-dark(#a8a29e, #78716c);
+  padding: 48px 0 40px;
+
+  &::before,
+  &::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: light-dark(#e8e7e5, #282624);
+  }
 `);
 
 const emptyStyle = css(`


### PR DESCRIPTION
## Summary

- Adds 29 month-entry files spanning July 2023 to June 2026 (Mindgate → Adobe), replacing the single placeholder entry with real career content from `docs/timeline.md`
- Replaces the June 2026 placeholder entries (blog meta-content) with the actual June 2026 career decisions from the canonical timeline doc
- Applies design-taste improvements to the timeline UI: editorial month headings with amber left-border accent, fade-in animation for lazily-loaded entry lists, tactile hover translate on CVEntry items, ruled end-note, and BatchControl active-press feedback
- Adds a smoke-test covering every entry component via `import.meta.glob` eager-load; fixes function coverage threshold that had dropped to 65% after adding the new files

## Test plan

- [x] `npm run type:check` passes
- [x] `npm run lint` reports zero issues
- [x] `npm run test:run` — 206 unit tests pass across 32 files
- [x] `npm run test:coverage` — all four thresholds (lines/branches/functions/statements ≥ 80%) met
- [x] `npm run test:e2e` — 6 pre-existing skips, rest pass